### PR TITLE
Wrong paramter type.

### DIFF
--- a/JeevesLib.py
+++ b/JeevesLib.py
@@ -76,7 +76,7 @@ def restrict(varLabel, pred, use_empty_env=False):
     """Associates a policy with a label.
 
     :param varLabel: Label to associate with policy.
-    :type varLabel: string
+    :type varLabel: Var
     :param pred: Policy: function taking output channel and returning Boolean result.
     :type pred: T -> bool, where T is the type of the output channel
     """


### PR DESCRIPTION
The type of `varLabel` parameter is `fast.AST.Var` but the documentation states that the type is `string`.
```
>>> l = JeevesLib.mkLabel('l')
>>> l.__class__
<class 'fast.AST.Var'>
```