### PR TITLE
Django 1.10 compatibility updates

### DIFF
--- a/fast/AST.py
+++ b/fast/AST.py
@@ -507,7 +507,10 @@ class Facet(FExpr):
 								lambda : self.thn.__len__(),
 								lambda : self.els.__len__())
 		else:
-			raise TypeError("cannot take len of non-object; type %s" % self.type.__name__)
+                        # TODO: Figure out why we get to this error, and
+                        # whether returning 1 is a complete solution or just a bandaid
+			#raise TypeError("cannot take len of non-object; type %s" % self.type.__name__)
+                        return 1
 
 	def __getstate__(self):
 		return "<%s:%s?%s>" % \

--- a/jeevesdb/JeevesModel.py
+++ b/jeevesdb/JeevesModel.py
@@ -8,7 +8,7 @@ from django.db import models
 from django.db.models.query import QuerySet
 from django.db.models import Manager
 from django.db.models import CharField
-from django.db.models.loading import get_model
+from django.apps import apps
 import django.db.models.fields.related
 
 import JeevesLib
@@ -38,7 +38,7 @@ class JeevesQuerySet(QuerySet):
                 # Get the model that corresponds to the application label and
                 # model name.
                 # TODO: Make get_model faster?
-                model = get_model(app_label, model_name)
+                model = apps.get_model(app_label, model_name)
 
                 # Gets the current row so we can feed it to the policy.
                 # TODO: Figure out why we need the faceted value here...
@@ -238,10 +238,7 @@ class JeevesManager(Manager):
     """
     @JeevesLib.supports_jeeves
     def get_queryset(self):
-        return (super(JeevesManager, self).get_queryset()
-            ._clone(klass=JeevesQuerySet)
-              .order_by('jeeves_id')
-           )
+        return JeevesQuerySet(self.model, using=self._db).order_by('jeeves_id')
 
     def all(self):
         return super(JeevesManager, self).all().all()
@@ -276,7 +273,7 @@ def acquire_label_by_name(app_label, label_name, obj=None):
         
         # Get the model that corresponds to the application label and model
         # name.
-        model = get_model(app_label, model_name)
+        model = apps.get_model(app_label, model_name)
 
         # Gets the current row so we can feed it to the policy.
         if obj==None:
@@ -353,12 +350,12 @@ class JeevesModel(models.Model):
                         if hasattr(self, '_meta') else []
         if name in field_names and \
             name not in ('jeeves_vars', 'jeeves_id', 'id'):
-            old_val = getattr(self, name) if hasattr(self, name) else \
-                        Unassigned("attribute '%s' in %s" % \
-                            (name, self.__class__.__name__))
-            models.Model.__setattr__(
-                self, name, JeevesLib.jassign(
-                    old_val, value, self.jeeves_base_env))
+            if name in self.__dict__:
+                old_val = getattr(self, name)
+            else:
+                old_val = Unassigned("attribute '%s' in %s" % (name, self.__class__.__name__))
+            models.Model.__setattr__(self,
+                name, JeevesLib.jassign(old_val, value, self.jeeves_base_env))
         else:
             models.Model.__setattr__(self, name, value)
 
@@ -636,19 +633,22 @@ class JeevesForeignKey(ForeignObject):
     @JeevesLib.supports_jeeves
     def __init__(self, to, *args, **kwargs):
         self.to = to
+        if (isinstance(to,basestring)):
+            super(JeevesForeignKey, self).__init__(
+                    to, kwargs.pop("on_delete",models.DO_NOTHING), kwargs.pop("from_fields",[]), kwargs.pop("to_fields",[]), *args, **kwargs)
+        else:
+            self.join_field = to._meta.pk
+            for field in to._meta.fields:
+                if field.name == 'jeeves_id':
+                    self.join_field = field
+                    break
+                else:
+                    # support non-Jeeves tables
+                    self.join_field = to._meta.pk
+                    #raise Exception("Need jeeves_id field")
 
-        for field in self.to._meta.fields:
-            if field.name == 'jeeves_id':
-                self.join_field = field
-                break
-            else:
-                # support non-Jeeves tables
-                self.join_field = to._meta.pk
-                #raise Exception("Need jeeves_id field")
-
-        kwargs['on_delete'] = models.DO_NOTHING
-        super(JeevesForeignKey, self).__init__(
-            to, [self], [self.join_field], *args, **kwargs)
+            super(JeevesForeignKey, self).__init__(
+                    to, models.DO_NOTHING, [self], [self.join_field], *args, **kwargs)
         self.db_constraint = False
 
     @JeevesLib.supports_jeeves

--- a/jeevesdb/JeevesModel.py
+++ b/jeevesdb/JeevesModel.py
@@ -667,6 +667,14 @@ class JeevesForeignKey(ForeignObject):
         column = self.db_column or attname
         return attname, column
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(JeevesForeignKey, self).deconstruct()
+        #kwargs['to'] = self.to
+        kwargs.pop("from_fields",None)
+        kwargs.pop("to_fields",None)
+        kwargs.pop("on_delete",None)
+        return name, path, args, kwargs
+
     '''
     @JeevesLib.supports_jeeves
     def db_type(self, connection):


### PR DESCRIPTION
A few changes made so that JeevesModel and JeevesForeignKey work with an application built with Django 1.10. The demos in this repo were made with 1.6, and I have not updated them, so they won't work with this update.

I have not thoroughly tested this for completeness or correctness; it's possible that there are some bugs that didn't come up in the demo I was running. It's also possible that someone more familiar with the code may be able to find better solutions than I did for some of the issues Django 1.10 introduced.

I could make a pull request for a different branch, if master isn't preferred.